### PR TITLE
Rasterize channel bugfixes

### DIFF
--- a/threedi_beta_processing/rasterize_channel.py
+++ b/threedi_beta_processing/rasterize_channel.py
@@ -429,17 +429,18 @@ class CrossSectionLocation:
             z_ordinates=z,
         )
 
-    def clone(self) -> 'CrossSectionLocation':
-        clone = self.__init__(
-            id=self.id,
-            reference_level=self.reference_level,
-            bank_level=self.bank_level,
-            y_ordinates=self.y_ordinates,
-            z_ordinates=self.z_ordinates - self.reference_level,
-            geometry=self.geometry,
-            parent=self.parent,
+    @classmethod
+    def clone(cls, source: 'CrossSectionLocation') -> 'CrossSectionLocation':
+        clone = cls(
+            id=source.id,
+            reference_level=source.reference_level,
+            bank_level=source.bank_level,
+            y_ordinates=source.y_ordinates,
+            z_ordinates=source.z_ordinates - source.reference_level,
+            geometry=source.geometry,
+            parent=source.parent,
         )
-        clone._position_normalized = self._position_normalized
+        clone._position_normalized = source._position_normalized
         return clone
 
     @property
@@ -941,7 +942,7 @@ class Channel:
             geometry=LineString([(Point(vertex)) for vertex in self.geometry.coords[:vertex_index + 1]])
         )
         for xsec in self.cross_section_locations:
-            xsec_copy = xsec.clone()
+            xsec_copy = CrossSectionLocation.clone(xsec)
             first_part.add_cross_section_location(xsec_copy)
             # A bit hacky but quick way to give cross-section location a "ghost" location on its new channel
             xsec_copy_idx = first_part.cross_section_location_index(xsec.id)
@@ -960,7 +961,7 @@ class Channel:
             geometry=LineString([(Point(vertex)) for vertex in self.geometry.coords[vertex_index:]])
         )
         for xsec in reversed(self.cross_section_locations):
-            xsec_copy = deepcopy(xsec)
+            xsec_copy = CrossSectionLocation.clone(xsec)
             last_part.add_cross_section_location(xsec_copy)
 
             # A bit hacky but quick way to give this cross-section location a "ghost" location on its new channel

--- a/threedi_beta_processing/rasterize_channel.py
+++ b/threedi_beta_processing/rasterize_channel.py
@@ -851,6 +851,7 @@ class Channel:
         # Regenerate parallel offsets if offset 0 is not included
         if 0 not in channel_to_update.unique_offsets:
             channel_to_update.generate_parallel_offsets(offset_0=True)
+            channel_to_update.fill_parallel_offsets()
 
         channel_to_update_offsets = []
         channel_to_update_points = []

--- a/threedi_beta_processing/test_rasterize_channel/debug.py
+++ b/threedi_beta_processing/test_rasterize_channel/debug.py
@@ -88,12 +88,12 @@ def read_from_geopackage(
 
 
 # gpkg_path = r"C:\Users\leendert.vanwolfswin\Documents\rasterize_channel test data\Olof Geul\geul_oost.gpkg"
-gpkg_path = r"C:\Users\leendert.vanwolfswin\Documents\rasterize_channel test data\MKDC\Mekong operational model.gpkg"
-pixel_size = 5.0
+gpkg_path = r"C:\Users\leendert.vanwolfswin\Downloads\Eibergen en Neede.gpkg"
+pixel_size = 0.5
 
 input_channels, input_cross_section_locations = read_from_geopackage(
     path=gpkg_path,
-    channel_ids=[1070],
+    channel_ids=[2],
     # channel_ids=[784],
     wall_displacement=pixel_size/4.0,
     simplify_tolerance=0.01
@@ -109,8 +109,9 @@ for input_channel in input_channels.values():
     # input_channel.generate_parallel_offsets()
     # num_points = np.sum([len(po.geometry.coords) for po in input_channel.parallel_offsets])
     # print(num_points)
-
-    channels += input_channel.make_valid()
+    valid = input_channel.make_valid()
+    channels += valid
+    print(f"Done with channel {input_channel.id}")
 # # fill_wedges(channels)
 # #
 # for channel in channels:


### PR DESCRIPTION
- Bugfix: prevent `TypeError("cannot pickle 'QVariant' object`") by replacing `deepcopy(xsec)` by `CrossSectionLocation.clone(xsec)`
- Bugfix: if cross-section locations had no entry at width 0, the whole channel (or entire sections of it) were missing in the end result; this has been fixed